### PR TITLE
Important bugfix: requests that have targets to multiple servers are now handled correctly

### DIFF
--- a/src/uaf/client/invocations/baseserviceinvocation.h
+++ b/src/uaf/client/invocations/baseserviceinvocation.h
@@ -369,26 +369,32 @@ namespace uafc
          */
         uaf::Status copyToResult(SessionResultType& result)
         {
-            uaf::Status ret;
+            uaf::Status ret(uaf::statuscodes::Good);
 
-            if (result.targets.size() == resultTargets_.size())
+            if (resultTargets_.size() != ranks_.size())
+                ret.setStatus(uaf::statuscodes::UnexpectedError,
+                              "Bug in BaseServiceInvocation: " \
+                              "number of result targets (%d) != number of ranks (%d)",
+                              resultTargets_.size(), ranks_.size());
+
+
+            for (std::size_t i = 0; i < resultTargets_.size() && ret.isGood(); i++)
             {
-                for (std::size_t i = 0; i < resultTargets_.size(); i++)
+                std::size_t rank = ranks_[i];
+
+                if (rank < result.targets.size())
                 {
-                    result.targets[ranks_[i]] = resultTargets_[i];
-                    result.targets[ranks_[i]].clientConnectionId
+                    result.targets[rank] = resultTargets_[i];
+                    result.targets[rank].clientConnectionId
                         = sessionInformation_.clientConnectionId;
                 }
-
-                ret.setGood();
+                else
+                {
+                    ret.setStatus(uaf::statuscodes::UnexpectedError,
+                                  "Bug in BaseServiceInvocation: rank (%d) > targets.size() (%d)",
+                                  rank, result.targets.size());
+                }
             }
-            else
-            {
-                ret.setStatus(uaf::statuscodes::UnexpectedError,
-                              "Result (%d targets) does not match the received resultTargets " \
-                              "(%d targets)", result.targets.size(), resultTargets_.size());
-            }
-
             return ret;
         }
 
@@ -402,25 +408,32 @@ namespace uafc
          */
         uaf::Status copyToResult(SubscriptionResultType& result)
         {
-            uaf::Status ret;
+            uaf::Status ret(uaf::statuscodes::Good);
 
-            if (result.targets.size() == resultTargets_.size())
+            if (resultTargets_.size() != ranks_.size())
+                ret.setStatus(uaf::statuscodes::UnexpectedError,
+                              "Bug in BaseServiceInvocation: " \
+                              "number of result targets (%d) != number of ranks (%d)",
+                              resultTargets_.size(), ranks_.size());
+
+
+            for (std::size_t i = 0; i < resultTargets_.size() && ret.isGood(); i++)
             {
-                for (std::size_t i = 0; i < resultTargets_.size(); i++)
+                std::size_t rank = ranks_[i];
+
+                if (rank < result.targets.size())
                 {
-                    result.targets[ranks_[i]] = resultTargets_[i];
-                    result.targets[ranks_[i]].clientConnectionId
+                    result.targets[rank] = resultTargets_[i];
+                    result.targets[rank].clientConnectionId
                         = sessionInformation_.clientConnectionId;
                 }
-
-                ret.setGood();
+                else
+                {
+                    ret.setStatus(uaf::statuscodes::UnexpectedError,
+                                  "Bug in BaseServiceInvocation: rank (%d) > targets.size() (%d)",
+                                  rank, result.targets.size());
+                }
             }
-            else
-            {
-                ret.setStatus(uaf::statuscodes::UnexpectedError,
-                              "Result does not match the received result targets");
-            }
-
             return ret;
         }
 
@@ -436,14 +449,15 @@ namespace uafc
         {
             uaf::Status ret;
 
-            if (result.targets.size() == resultTargets_.size())
+            if (ranks_.size() == resultTargets_.size())
             {
                 ret.setGood();
             }
             else
             {
                 ret.setStatus(uaf::statuscodes::UnexpectedError,
-                              "Result does not match the received result targets");
+                              "Bug in BaseServiceInvocation: Ranks do not match the received " \
+                              "result targets");
             }
 
             return ret;
@@ -461,14 +475,15 @@ namespace uafc
         {
             uaf::Status ret;
 
-            if (result.targets.size() == resultTargets_.size())
+            if (ranks_.size() == resultTargets_.size())
             {
                 ret.setGood();
             }
             else
             {
                 ret.setStatus(uaf::statuscodes::UnexpectedError,
-                              "Result does not match the received result targets");
+                              "Bug in BaseServiceInvocation: Ranks do not match the received " \
+                              "result targets");
             }
 
             return ret;


### PR DESCRIPTION
So for example (in Python): 
- myClient.read([address0, address1])
- myClient.createMonitoredData([address0, address1], notificationCallbacks=[myCallback0, myCallback2])
- ...

are now handled correctly **also** in case address0 and address1 point to nodes that are hosted by different servers.
