### PR TITLE
Bugfix: remove #include <windows.h>

### DIFF
--- a/src/uaf/util/helperfunctions.h
+++ b/src/uaf/util/helperfunctions.h
@@ -25,9 +25,7 @@
 #include <string>
 #include <algorithm>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
+#ifndef _WIN32
 #include <limits.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
windows.h doesn't need to be included, so it's now removed as it causes troubles in combination with SDK 1.4.3. See https://github.com/uaf/uaf/issues/51.