### PR TITLE
bugfix: MACRO needed to be changed to FUNCTION

### DIFF
--- a/src/UafMacros.cmake
+++ b/src/UafMacros.cmake
@@ -423,9 +423,9 @@ ENDMACRO(setPyUafTargetProperties)
 
 # ----------------------------------------------------------------------------
 # copyFile(file, to)
-#    This macro will copy the given file to the given destination.
+#    This function will copy the given file to the given destination.
 # ----------------------------------------------------------------------------
-MACRO(copyFile _FILE _TO)
+FUNCTION(copyFile _FILE _TO)
 
     if( EXISTS "${_FILE}" )
         MESSAGE(STATUS "Copying ${_FILE} to ${_TO}")
@@ -434,7 +434,7 @@ MACRO(copyFile _FILE _TO)
         MESSAGE(FATAL_ERROR "Copying ${_FILE} failed: file not found!")
     endif( EXISTS "${_FILE}" )
 
-ENDMACRO(copyFile)
+ENDFUNCTION(copyFile)
 
 # ----------------------------------------------------------------------------
 # copySdkLibraries()


### PR DESCRIPTION
... because otherwise the given / separators are not converted into Windows-separators. On some platforms this causes problems (invalid paths).

See https://github.com/uaf/uaf/issues/61#issuecomment-108476097
Credits to [robi-wan](https://github.com/robi-wan) for finding the bug providing the patch.

Reason:
Note that the parameters to a macro and values are not variables in the usual CMake sense. They are string replacements much like the c preprocessor would do with a macro. If you want true CMake variables you should look at the function command.