### PR TITLE
Tweak helper scripts to prepend uaf\lib directory to environment variables

### DIFF
--- a/examples/uaf-commandprompt.bat
+++ b/examples/uaf-commandprompt.bat
@@ -2,14 +2,14 @@
 
 echo This Windows script (uaf-commandprompt.bat) should be executed in Command prompt
 echo and does the following:
-echo  - it appends the uaf\lib directory to the PATH environment variable
-echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
+echo  - it prepends the uaf\lib directory to the PATH environment variable
+echo  - it prepends the uaf\lib directory to the PYTHONPATH environment variable
 echo
 :: =============================================================================
 
 cd /d %~dp0
-set PATH=%PATH%;%~dp0..\lib
-set PYTHONPATH=%PYTHONPATH%;%~dp0..\lib
+set PATH=%~dp0..\lib;%PATH%
+set PYTHONPATH=%~dp0..\lib;%PYTHONPATH%
 
 echo.
 echo New PATH: 

--- a/examples/uaf-powershell.bat
+++ b/examples/uaf-powershell.bat
@@ -2,8 +2,8 @@
 
 echo This Windows script (uaf-powershell.bat) should be executed in Windows PowerShell
 echo and does the following:
-echo  - it appends the uaf\lib directory to the PATH environment variable
-echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
+echo  - it prepends the uaf\lib directory to the PATH environment variable
+echo  - it prepends the uaf\lib directory to the PYTHONPATH environment variable
 :: =============================================================================
 
 :: How it works:
@@ -11,8 +11,8 @@ echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
 ::  - from this environment, launch Windows PowerShell
 
 cd /d %~dp0
-set PATH=%PATH%;%~dp0..\lib
-set PYTHONPATH=%PYTHONPATH%;%~dp0..\lib
+set PATH=%~dp0..\lib;%PATH%
+set PYTHONPATH=%~dp0..\lib;%PYTHONPATH%
 
 echo.
 echo New PATH: 

--- a/unittests/pyuaftests/client/client_connectionstatus.py
+++ b/unittests/pyuaftests/client/client_connectionstatus.py
@@ -64,10 +64,10 @@ class ClientConnectionStatusTest(unittest.TestCase):
         plcOpenNsUri = "http://PLCopen.org/OpcUa/IEC61131-3/"
         
         # define some nodeids
-        self.id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
+        self.node_id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
         
         # define some addresses
-        self.address = Address(ExpandedNodeId(self.id, self.serverUri))
+        self.address = Address(ExpandedNodeId(self.node_id, self.serverUri))
     
 
     def test_client_Client_register_all_connectionstatuses_and_read_node(self):

--- a/unittests/pyuaftests/client/client_keepalive.py
+++ b/unittests/pyuaftests/client/client_keepalive.py
@@ -58,10 +58,10 @@ class ClientKeepAliveTest(unittest.TestCase):
         plcOpenNsUri = "http://PLCopen.org/OpcUa/IEC61131-3/"
         
         # define some nodeids
-        self.id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
+        self.node_id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
         
         # define some addresses
-        self.address = Address(ExpandedNodeId(self.id, self.serverUri))
+        self.address = Address(ExpandedNodeId(self.node_id, self.serverUri))
     
     
     def test_client_Client_register_keepalivecallback_and_monitor_static_node(self):

--- a/unittests/pyuaftests/client/client_subscriptionstatus.py
+++ b/unittests/pyuaftests/client/client_subscriptionstatus.py
@@ -64,10 +64,10 @@ class ClientSubscriptionStatusTest(unittest.TestCase):
         plcOpenNsUri = "http://PLCopen.org/OpcUa/IEC61131-3/"
         
         # define some nodeids
-        self.id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
+        self.node_id = NodeId(opcuaidentifiers.OpcUaId_Server_Auditing, 0)
         
         # define some addresses
-        self.address = Address(ExpandedNodeId(self.id, self.serverUri))
+        self.address = Address(ExpandedNodeId(self.node_id, self.serverUri))
     
 
     def test_client_Client_register_all_subscriptionstatuses_and_monitor_node(self):

--- a/unittests/uaf-commandprompt.bat
+++ b/unittests/uaf-commandprompt.bat
@@ -2,14 +2,14 @@
 
 echo This Windows script (uaf-commandprompt.bat) should be executed in Command prompt
 echo and does the following:
-echo  - it appends the uaf\lib directory to the PATH environment variable
-echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
+echo  - it prepends the uaf\lib directory to the PATH environment variable
+echo  - it prepends the uaf\lib directory to the PYTHONPATH environment variable
 echo
 :: =============================================================================
 
 cd /d %~dp0
-set PATH=%PATH%;%~dp0..\lib
-set PYTHONPATH=%PYTHONPATH%;%~dp0..\lib
+set PATH=%~dp0..\lib;%PATH%
+set PYTHONPATH=%~dp0..\lib;%PYTHONPATH%
 
 echo.
 echo New PATH: 

--- a/unittests/uaf-powershell.bat
+++ b/unittests/uaf-powershell.bat
@@ -2,8 +2,8 @@
 
 echo This Windows script (uaf-powershell.bat) should be executed in Windows PowerShell
 echo and does the following:
-echo  - it appends the uaf\lib directory to the PATH environment variable
-echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
+echo  - it prepends the uaf\lib directory to the PATH environment variable
+echo  - it prepends the uaf\lib directory to the PYTHONPATH environment variable
 :: =============================================================================
 
 :: How it works:
@@ -11,8 +11,8 @@ echo  - it appends the uaf\lib directory to the PYTHONPATH environment variable
 ::  - from this environment, launch Windows PowerShell
 
 cd /d %~dp0
-set PATH=%PATH%;%~dp0..\lib
-set PYTHONPATH=%PYTHONPATH%;%~dp0..\lib
+set PATH=%~dp0..\lib;%PATH%
+set PYTHONPATH=%~dp0..\lib;%PYTHONPATH%
 
 echo.
 echo New PATH: 


### PR DESCRIPTION
Prepending the uaf\lib directory assures that the correct libraries are
found e.g. for executing the tests.

I had an entry in the PATH environment variable which pointed to an OPC
UA SDK 1.3.3 - that caused the error "ImportError: DLL load failed: The
specified procedure could not be found." when running the tests. Tests
on master require OPC UA SDK 1.4.x.