### PR TITLE
Browse of an addresspace provided by the Prosys stack leads to status…

### DIFF
--- a/src/uaf/util/namespacearray.cpp
+++ b/src/uaf/util/namespacearray.cpp
@@ -395,7 +395,7 @@ namespace uaf
             NodeId nodeId = expandedNodeId.nodeId();
             nodeId.setNameSpaceUri(string(UaString(&opcUaExpandedNodeId.NamespaceUri).toUtf8()));
             expandedNodeId.setNodeId(nodeId);
-            ret.isGood();
+            ret.setGood();
         }
         else if (findNamespaceUri(opcUaExpandedNodeId.NodeId.NamespaceIndex, namespaceUri))
         {


### PR DESCRIPTION
… Uncertain. Fix: Set statuscode to Good when an expanded nodeId has a namespace uri.