### PR TITLE
bugfix for uninitialized booleans

### DIFF
--- a/src/uaf/util/genericstructurevalue.cpp
+++ b/src/uaf/util/genericstructurevalue.cpp
@@ -144,7 +144,7 @@ namespace uaf
 	{
 		UaString uaFieldName(fieldName.c_str());
 		int index;
-		bool found;
+		bool found = false;
 		for(index=0; index<uaGenericStructureValue_.definition().childrenCount() && !found; index++)
 		{
 			if (uaGenericStructureValue_.definition().child(index).name() == uaFieldName)

--- a/src/uaf/util/genericunionvalue.cpp
+++ b/src/uaf/util/genericunionvalue.cpp
@@ -143,7 +143,7 @@ namespace uaf
     {
         UaString uaFieldName(fieldName.c_str());
         int index;
-        bool found;
+        bool found = false;
         for(index=0; index<uaGenericUnionValue_.definition().childrenCount() && !found; index++)
         {
             if (uaGenericUnionValue_.definition().child(index).name() == uaFieldName)
@@ -209,7 +209,7 @@ namespace uaf
 	{
 		UaString uaFieldName(fieldName.c_str());
 		int index;
-		bool found;
+		bool found = false;
 		for(index=0; index<uaGenericUnionValue_.definition().childrenCount() && !found; index++)
 		{
 			if (uaGenericUnionValue_.definition().child(index).name() == uaFieldName)


### PR DESCRIPTION
This is a potential fix for:

terminate called after throwing an instance of 'std::bad_alloc'
              what():  std::bad_alloc
            Aborted (core dumped)

The issue was found using Cppcheck.