### PR TITLE
Remove hardcoded setting of CMake build type.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,9 @@ include(UafMacros)
 # Handle some command line options (default values are the same as for the SDK!)
 handleOptions()
 
+# Set the default build type to release
+setDefaultBuildTypeToRelease()
+
 # Set the UAF compiler flags
 setUafCompilerFlags()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,9 +18,6 @@ include(UafMacros)
 # Handle some command line options (default values are the same as for the SDK!)
 handleOptions()
 
-# Set the build type to release
-setBuildTypeToRelease()
-
 # Set the UAF compiler flags
 setUafCompilerFlags()
 

--- a/src/UafMacros.cmake
+++ b/src/UafMacros.cmake
@@ -1,4 +1,18 @@
 # ----------------------------------------------------------------------------
+# setDefaultBuildTypeToRelease()
+#    This macro sets the build type to Release, if no
+#    build type has been set yet.
+# ----------------------------------------------------------------------------
+MACRO(setDefaultBuildTypeToRelease)
+
+    IF(NOT DEFINED CMAKE_BUILD_TYPE AND NOT DEFINED CMAKE_CONFIGURATION_TYPES)
+        set (CMAKE_BUILD_TYPE Release)
+        set (CMAKE_CONFIGURATION_TYPES "Release")
+    ENDIF()
+
+ENDMACRO(setDefaultBuildTypeToRelease)
+
+# ----------------------------------------------------------------------------
 # handleOptions()
 #    This macro handles some command line options.
 # ----------------------------------------------------------------------------

--- a/src/UafMacros.cmake
+++ b/src/UafMacros.cmake
@@ -1,15 +1,4 @@
 # ----------------------------------------------------------------------------
-# setBuildTypeToRelease()
-#    This macro sets the build type to Release.
-# ----------------------------------------------------------------------------
-MACRO(setBuildTypeToRelease)
-
-    set (CMAKE_BUILD_TYPE Release)
-    set (CMAKE_CONFIGURATION_TYPES "Release")
-
-ENDMACRO(setBuildTypeToRelease)
-
-# ----------------------------------------------------------------------------
 # handleOptions()
 #    This macro handles some command line options.
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This allows more flexibility in the build, making it possible to use
different build types without having to change the CMake configuration
files. This is standard CMake practice; allow passing the build type on the command line
when invoking cmake: `cmake -DCMAKE_BUILD_TYPE=...`