### PR TITLE
Fix memory allocation bug in TranslateBrowsePathToNodeIds response handling

### DIFF
--- a/src/uaf/client/invocations/translatebrowsepathstonodeidsinvocation.cpp
+++ b/src/uaf/client/invocations/translatebrowsepathstonodeidsinvocation.cpp
@@ -177,6 +177,10 @@ namespace uaf
                 // update the status code
                 targets[i].opcUaStatusCode = uaBrowsePathResults_[i].StatusCode;
 
+                // Make sure we don't try to process an empty or null array of target results.
+                if(uaBrowsePathResults_[i].NoOfTargets <= 0)
+                    continue;
+
                 // declare the number of "targets of the current ResultTarget"
                 uint32_t noOfResultTargetTargets = uaBrowsePathResults_[i].NoOfTargets;
 


### PR DESCRIPTION
When making a TranslateBrowsePathsToNodeIds service request using a non-existent
browsepath, the service reply contains a Null array (https://reference.opcfoundation.org/Core/docs/Part6/5.1.9/)
In OPC UA Binary encoding, the length of a Null array is encoded as `-1`.

We now check for this signed integer value before converting it to an `uint32_t`
and using it as an argument to `std::vector<T>::resize`.
This is needed, as converting `-1` to an `uint32_t` results in a value
of 2^32, causing `std::bad_alloc` to be thrown in most cases.